### PR TITLE
Fix dropdown overlap

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -260,3 +260,8 @@ h1 {
 .popover {
     z-index: 9999 !important;
 }
+
+/* Ensure dropdown menus are displayed above other cards */
+.Select-menu, .Select-menu-outer {
+    z-index: 2000 !important;
+}

--- a/dash_mrewithedas.py
+++ b/dash_mrewithedas.py
@@ -237,7 +237,7 @@ app.layout = html.Div([
                     options=[],
                     multi=True,
                     placeholder="Select evidence variables",
-                    style={'width': '50%', 'margin': '0 auto'}
+                    style={'width': '50%', 'margin': '0 auto', 'zIndex': 1000}
                 ),
                 html.Div(id='evidence-values-container')
             ]),
@@ -285,7 +285,7 @@ app.layout = html.Div([
                     options=[],
                     multi=True,
                     placeholder="Select target variables",
-                    style={'width': '50%', 'margin': '0 auto'}
+                    style={'width': '50%', 'margin': '0 auto', 'zIndex': 1000}
                 ),
                 html.Div(
                     'Note: Some algorithms need at least 2 target variables (UMDAcat_mre2, GA MRE, etc.)',
@@ -618,7 +618,7 @@ def update_evidence_values(evidence_vars, stored_network):
                                 id={'type': 'evidence-value-dropdown', 'index': var},
                                 options=[{'label': s, 'value': s} for s in states],
                                 value=states[0] if states else None,
-                                style={'width': '60%'}
+                                style={'width': '60%', 'zIndex': 1000}
                             )
                         ],
                         style={'display': 'flex', 'alignItems': 'center', 'justifyContent': 'center'}


### PR DESCRIPTION
## Summary
- increase z-index for dropdown elements
- add CSS rules to keep dropdowns above surrounding cards

## Testing
- `python -m py_compile dash_mrewithedas.py mre.py mrewithedas_example.py`
- `flake8` *(fails: command not found)*